### PR TITLE
Update dependencies

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -31,7 +31,7 @@ namespace weather
                 .AddJwtBearer(options =>
                 {
                     options.Authority = Configuration["Authorization:Issuer"];
-                    options.Audience = Configuration["Authorization:ClientId"];
+                    options.Audience = Configuration["Authorization:Audience"];
                 });
 
             services.AddAuthorization(options =>

--- a/weather.csproj
+++ b/weather.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.1.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated to .NET 8
- Added Microsoft.IdentityModel.Protocols.OpenIdConnect (8.1.2) dependency to solve issue with JWT verification
- Fixed code correctly look for Configuration["Authorization:Audience"] instead of Configuration["Authorization:ClientId"];